### PR TITLE
Handle redirect to `/zipkin`

### DIFF
--- a/js/ZipkinPlugin.js
+++ b/js/ZipkinPlugin.js
@@ -44,12 +44,13 @@ export default class ZipkinPlugin {
   }
 
   async addZipkinUrl(url, saveToStorage = true) {
+    // Fetch the endpoint to check if we get redirected
     const fetchUrl = await fetch(url);
 
     // Never actually download the body
     await fetchUrl.body.cancel();
 
-    if (fetchUrl.redirected) {
+    if (fetchUrl.redirected && fetchUrl.url === `${url}/zipkin/`) {
       url = `${url}/zipkin`
     }
 

--- a/js/ZipkinPlugin.js
+++ b/js/ZipkinPlugin.js
@@ -43,7 +43,16 @@ export default class ZipkinPlugin {
     this.storage.set('zipkinUrls', this.zipkinUrls.map(z => ({url: z.url})));
   }
 
-  addZipkinUrl(url, saveToStorage = true) {
+  async addZipkinUrl(url, saveToStorage = true) {
+    const fetchUrl = await fetch(url);
+
+    // Never actually download the body
+    await fetchUrl.body.cancel();
+
+    if (fetchUrl.redirected) {
+      url = `${url}/zipkin`
+    }
+
     this.zipkinUrls.push({
       url,
       statusCheck: this.makeZipkinCheckInterval(url)

--- a/js/attachBeforeSendHeadersListener.js
+++ b/js/attachBeforeSendHeadersListener.js
@@ -22,7 +22,7 @@ export default function attachBeforeSendHeadersListener(webRequest) {
       'X-B3-SpanId': traceId
     };
 
-    const modified = {
+    return {
       requestHeaders: [
         ...(details.requestHeaders || []),
         ...Object.keys(zipkinHeaders).map(key => ({
@@ -31,6 +31,5 @@ export default function attachBeforeSendHeadersListener(webRequest) {
         }))
       ]
     };
-    return modified;
   }, filter, ['blocking', 'requestHeaders']);
 }


### PR DESCRIPTION
This checks if a call to the host provided gives a redirect. If it does, just append `/zipkin` and call it a day.

A bit naive, but it works 🙂

No idea if it breaks the firefox plugin, I'm going to send a PR with a rewrite for it anyways (as mentioned in #15 the current API used is scheduled for removal)

PS: This need #16 to build correctly

Closes openzipkin/zipkin#1722