### PR TITLE
Use proper spdx license to avoid warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "gulp"
   },
   "author": "OpenZipkin",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
+  "repository": "openzipkin/zipkin-browser-extension",
   "devDependencies": {
     "babel-core": "^6.7.4",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
Currently 2 warnings are printed on install. This change removes them.

![image](https://user-images.githubusercontent.com/1404810/29995408-e5d3e6bc-8fe8-11e7-9db1-16a858243893.png)
